### PR TITLE
(bugfix) Fix `npm install`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,21 +2,10 @@
   "name": "gitfit",
   "version": "1.0.0",
   "description": "GitFit encourages programmers to embrace a balanced and healthy lifestyle.",
-  "main": "server.js",
-  "scripts": {
-    "test": "npm run test-server",
-    "start": "node server.js"
+  "main": "gulpfile.js",
+  "directories": {
+    "test": "tests"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/charismatic-invertebrates/gitfit"
-  },
-  "author": "",
-  "license": "Proprietary",
-  "bugs": {
-    "url": "https://github.com/charismatic-invertebrates/gitfit/issues"
-  },
-  "homepage": "https://github.com/charismatic-invertebrates/gitfit",
   "dependencies": {
     "body-parser": "^1.12.2",
     "browserify": "^9.0.7",
@@ -30,10 +19,10 @@
     "gulp-react": "^3.0.1",
     "gulp-sass": "^1.3.3",
     "gulp-watchify": "^0.5.0",
+    "jasmine": "^2.2.1",
     "jquery": "^2.1.3",
     "karma": "^0.12.31",
-    "mocha": "^2.2.1",
-    "mongodb": "^2.0.25",
+    "mongodb": "^2.0.27",
     "mongoose": "^4.0.1",
     "morgan": "^1.5.2",
     "nodemon": "^1.3.7",
@@ -45,17 +34,20 @@
     "watchify": "^3.1.0"
   },
   "devDependencies": {
-    "chai": "*",
-    "gulp-jasmine": "^2.0.1",
-    "jasmine": "^2.2.1",
-    "jasmine-core": "^2.2.0",
-    "karma": "^0.12.31",
-    "karma-jasmine": "^0.3.5",
-    "karma-phantomjs-launcher": "^1.9.16",
-    "karma-requirejs": "^0.2.2",
-    "mocha": "*",
-    "requirejs": "^2.1.17",
-    "supertest": "*",
-    "watchify": "^3.1.0"
-  }
+    "mocha": "^2.2.3"
+  },
+  "scripts": {
+    "test": "mocha",
+    "start": "node server.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/millionhari/gitfit.git"
+  },
+  "author": "",
+  "license": "Proprietary",
+  "bugs": {
+    "url": "https://github.com/millionhari/gitfit/issues"
+  },
+  "homepage": "https://github.com/millionhari/gitfit"
 }


### PR DESCRIPTION
Cleaned up `npm install`. To load last pull request, run `npm install` and then `gulp build` in terminal.
