### PR TITLE
Modularize client-side authentication, add Login functionality

### DIFF
--- a/client/src/js/components/CommitsBox.jsx
+++ b/client/src/js/components/CommitsBox.jsx
@@ -13,8 +13,8 @@ var CommitsBox = React.createClass({
     this.props.auth.sendToServer('pairing');
   },
 
-  loadAccount: function() {
-    this.props.auth.loadServerAccount();
+  syncAccount: function() {
+    this.props.auth.syncAccount();
   },
 
   render: function() {
@@ -24,7 +24,7 @@ var CommitsBox = React.createClass({
         <Chart parentId="commits-chart" currentValue={this.props.user.github.dailyCommits} max={this.props.max} />
         <a className="button" onClick={this.getProviderCode}>Login to Github</a>
         <a className="button" onClick={this.pairAccounts}>Pair Accounts</a>
-        <a className="button" onClick={this.loadAccount}>Load Account from Server</a>
+        <a className="button" onClick={this.syncAccount}>Sync Account</a>
       </div>
     );
   }

--- a/client/src/js/components/CommitsBox.jsx
+++ b/client/src/js/components/CommitsBox.jsx
@@ -4,8 +4,8 @@ var Chart = require('./Chart.jsx');
 var CommitsBox = React.createClass({
 
   // This function logs in to Github, and triggers a series of AJAX calls that extract the user's info, repos, and commits
-  loginGithub: function(e) {
-    this.props.auth.login('github');
+  getProviderCode: function(e) {
+    this.props.auth.getCode('github');
   },
   
   // This function logs the user object saved in App.jsx's state
@@ -22,7 +22,7 @@ var CommitsBox = React.createClass({
       <div className="commits-box">
         <h2>Commits</h2>
         <Chart parentId="commits-chart" currentValue={this.props.user.github.dailyCommits} max={this.props.max} />
-        <a className="button" onClick={this.loginGithub}>Login to Github</a>
+        <a className="button" onClick={this.getProviderCode}>Login to Github</a>
         <a className="button" onClick={this.pairAccounts}>Pair Accounts</a>
         <a className="button" onClick={this.loadAccount}>Load Account from Server</a>
       </div>

--- a/client/src/js/components/CommitsBox.jsx
+++ b/client/src/js/components/CommitsBox.jsx
@@ -10,7 +10,7 @@ var CommitsBox = React.createClass({
   
   // This function logs the user object saved in App.jsx's state
   pairAccounts: function() {
-    this.props.auth.pairAccounts();
+    this.props.auth.sendToServer('pairing');
   },
 
   loadAccount: function() {

--- a/client/src/js/components/StepsBox.jsx
+++ b/client/src/js/components/StepsBox.jsx
@@ -3,8 +3,8 @@ var Chart = require('./Chart.jsx');
 
 var StepsBox = React.createClass({
 
-  getProviderCode: function(service, skipPairing) {
-    this.props.auth.getCode(service, skipPairing);
+  getProviderCode: function(service, loginServer) {
+    this.props.auth.getCode(service, loginServer);
   },
 
   logUser: function() {
@@ -19,7 +19,7 @@ var StepsBox = React.createClass({
         <a className="button" onClick={this.getProviderCode.bind(null, 'fitbit')}>Login to FitBit</a>
         <a className="button" onClick={this.getProviderCode.bind(null, 'jawbone')}>Login to Jawbone</a>
         <a className="button" onClick={this.logUser}>Console log user info</a>
-        <a className="button" onClick={this.getProviderCode.bind(null, 'github', 'checkServer')}>Login to Pre-existing Account</a>
+        <a className="button" onClick={this.getProviderCode.bind(null, 'github', true)}>Login to Pre-existing Account</a>
         <a className="button" onClick={this.logUser}>Sync database with APIs</a>
       </div>
     );

--- a/client/src/js/components/StepsBox.jsx
+++ b/client/src/js/components/StepsBox.jsx
@@ -20,7 +20,6 @@ var StepsBox = React.createClass({
         <a className="button" onClick={this.getProviderCode.bind(null, 'jawbone')}>Login to Jawbone</a>
         <a className="button" onClick={this.logUser}>Console log user info</a>
         <a className="button" onClick={this.getProviderCode.bind(null, 'github', true)}>Login to Pre-existing Account</a>
-        <a className="button" onClick={this.logUser}>Sync database with APIs</a>
       </div>
     );
   }

--- a/client/src/js/components/StepsBox.jsx
+++ b/client/src/js/components/StepsBox.jsx
@@ -3,8 +3,8 @@ var Chart = require('./Chart.jsx');
 
 var StepsBox = React.createClass({
 
-  loginUser: function(service) {
-    this.props.auth.login(service);
+  getProviderCode: function(service, skipPairing) {
+    this.props.auth.getCode(service, skipPairing);
   },
 
   logUser: function() {
@@ -16,9 +16,11 @@ var StepsBox = React.createClass({
       <div className="steps-box">
         <h2>Steps</h2>
         <Chart parentId="steps-chart" currentValue={this.props.user.fitness.moves} max={this.props.max} />
-        <a className="button" onClick={this.loginUser.bind(null, 'fitbit')}>Login to FitBit</a>
-        <a className="button" onClick={this.loginUser.bind(null, 'jawbone')}>Login to Jawbone</a>
+        <a className="button" onClick={this.getProviderCode.bind(null, 'fitbit')}>Login to FitBit</a>
+        <a className="button" onClick={this.getProviderCode.bind(null, 'jawbone')}>Login to Jawbone</a>
         <a className="button" onClick={this.logUser}>Console log user info</a>
+        <a className="button" onClick={this.getProviderCode.bind(null, 'github', 'checkServer')}>Login to Pre-existing Account</a>
+        <a className="button" onClick={this.logUser}>Sync database with APIs</a>
       </div>
     );
   }

--- a/client/src/js/stores/auth.js
+++ b/client/src/js/stores/auth.js
@@ -26,11 +26,10 @@ var auth = function(){
       app.setState(React.addons.update(app.state, update));
     };
 
-
-
-
     // This switch statement sets all properties necessary to make an AJAX call.  This allows us to create one AJAX call, and make different calls depending on provider.
     switch(callLoc) {
+
+      // These cases handle getting a provider's code through chrome's WebAuthFlow
       case 'github-login':
         callParams = {
           url: 'https://github.com/login/oauth/authorize?client_id=' + keys.github.clientID,
@@ -65,7 +64,8 @@ var auth = function(){
           }
         };
         break;
-   
+
+      // These cases handle requests to and through our server   
       case 'paired-createAccount':
       callParams = {
         url: 'http://localhost:8000/api/auth/createAccount/',

--- a/server/APIs/apiHandler.js
+++ b/server/APIs/apiHandler.js
@@ -19,22 +19,24 @@ module.exports = {
       .then(function(response){
         userAccount.github.accessToken = response[1].access_token;
       })
-      // Get Fitness Provider token from code
+      // If there is a Fitness Provider, get its token from code
       .then(function(){
+        if( userAccount.fitness.provider !== null ) {
         var fitnessParams = assignRequestParams(userAccount.fitness.provider, 'getToken', userAccount.fitness.code);
-        return deferredRequest(fitnessParams);
-      })
-      // Save Fitness token to userAccount
-      .then(function(response) {
-        userAccount.fitness.accessToken = JSON.parse(response[1]).access_token;
-        return userAccount;
+        return deferredRequest(fitnessParams)
+          // Save Fitness token to userAccount
+          .then(function(response) {
+            userAccount.fitness.accessToken = JSON.parse(response[1]).access_token;
+            return userAccount;
+          });
+        }
       })
       .fail(function(error) {
         console.error('Error in apiHandler.getTokens, token exchange failed: ', error);
       });
   },
 
-  getGithubData: function(userAccount) {
+  getGithubUser: function(userAccount) {
     var githubUserParams = assignRequestParams('github', 'getUser', userAccount.github.accessToken);
 
     return deferredRequest(githubUserParams)
@@ -49,12 +51,16 @@ module.exports = {
           commitDates: [],
           commitCounts: []
         };
-      })
-      // Get Github Repo information
-      .then(function() {
-        var githubRepoParams = assignRequestParams('github', 'repos', userAccount.github);
-        return deferredRequest(githubRepoParams);
-      })
+        return userAccount;
+      });
+  },
+
+  getGithubData: function(userAccount) {
+    var githubRepoParams = assignRequestParams('github', 'repos', userAccount.github);
+
+    // Get Github Repo information
+    return deferredRequest(githubRepoParams)
+    
       // Extract individual repo names and store:
       .then(function(response){
         var repos = JSON.parse(response[1]);

--- a/server/APIs/apiHandler.js
+++ b/server/APIs/apiHandler.js
@@ -21,7 +21,7 @@ module.exports = {
       })
       // If there is a Fitness Provider, get its token from code
       .then(function(){
-        if( userAccount.fitness.provider !== null ) {
+        if( userAccount.fitness ) {
         var fitnessParams = assignRequestParams(userAccount.fitness.provider, 'getToken', userAccount.fitness.code);
         return deferredRequest(fitnessParams)
           // Save Fitness token to userAccount

--- a/server/auth/authController.js
+++ b/server/auth/authController.js
@@ -55,7 +55,7 @@ var auth = {
   },
 
   loginUser: function(req, res) {
-    var userAccount = req.query.accountCodes;
+    var userAccount = {github: {code: req.query.code} };
 
     // Exchange Github code for token
     apiHandler.getTokens(userAccount)
@@ -64,10 +64,12 @@ var auth = {
       return apiHandler.getGithubUser(userAccount);
     })
     .then(function() {
-      userCtrl.checkForUser(userAccount, res)
+      userCtrl.checkForUser(res, userAccount)
         .then(function(foundUser) {
           if( !foundUser ) {
-            res.send(404, 'No account found for this login');
+            res.status(404).send('No account found for this login');
+          } else {
+            console.log('We found a user');
           }
         });
     });

--- a/server/auth/authController.js
+++ b/server/auth/authController.js
@@ -9,7 +9,8 @@ var userCtrl = require('../users/userController.js');
 var auth = {
 
   // Save a new user in our database
-  createNewUserAccount: function(req, res, next){
+  createNewUserAccount: function(req, res){
+    console.log('creating a new user, allegedly');
     var userAccount = req.query.accountCodes;
     userAccount.time = req.query.timeframe;
 
@@ -18,11 +19,31 @@ var auth = {
 
       // Get Github User information
       .then(function() {
-        return apiHandler.getGithubData(userAccount);
+        return apiHandler.getGithubUser(userAccount);
       })
+
+      // Check if this user is in our database, if so, reply with user.  Otherwise, continue to create a new user
+      .then(function(userAccount) {
+        console.log(userAccount);
+        return userCtrl.checkForUser(res, userAccount)
+          .then(function(foundUser) {
+            if( !foundUser ) {
+              console.log('are we at least acknowledging that we didn\'t find a user?');
+              return continueCreation(userAccount);
+            }
+          });
+      });
+
+
+    var continueCreation = function() {
+      console.log('are we making the hop to the other set of promises?');
+
+      // Get github api information
+      return apiHandler.getGithubData(userAccount)
 
       // Get user's Fitness Tracker's step-count
       .then(function() {
+        console.log('are we getting more data?');
         return apiHandler.getFitnessData(userAccount);
       })
 
@@ -36,7 +57,27 @@ var auth = {
         console.error(error);
         res.send('Error creating new user', error);
       });
+    };
   },
+
+  loginUser: function(req, res) {
+    var userAccount = req.query.accountCodes;
+
+    // Exchange Github code for token
+    apiHandler.getTokens(userAccount)
+
+    .then(function() {
+      return apiHandler.getGithubUser(userAccount);
+    })
+    .then(function() {
+      userCtrl.checkForUser(userAccount, res)
+        .then(function(foundUser) {
+          if( !foundUser ) {
+            res.send(404, 'No account found for this login');
+          }
+        });
+    });
+  }
 };
 
 module.exports = auth;

--- a/server/auth/authController.js
+++ b/server/auth/authController.js
@@ -60,9 +60,12 @@ var auth = {
     // Exchange Github code for token
     apiHandler.getTokens(userAccount)
 
+    // Get user information from Github
     .then(function() {
       return apiHandler.getGithubUser(userAccount);
     })
+
+    // Use user information to query our database for a pre-existing user
     .then(function() {
       userCtrl.checkForUser(res, userAccount)
         .then(function(foundUser) {

--- a/server/auth/authController.js
+++ b/server/auth/authController.js
@@ -10,7 +10,6 @@ var auth = {
 
   // Save a new user in our database
   createNewUserAccount: function(req, res){
-    console.log('creating a new user, allegedly');
     var userAccount = req.query.accountCodes;
     userAccount.time = req.query.timeframe;
 
@@ -24,32 +23,27 @@ var auth = {
 
       // Check if this user is in our database, if so, reply with user.  Otherwise, continue to create a new user
       .then(function(userAccount) {
-        console.log(userAccount);
         return userCtrl.checkForUser(res, userAccount)
           .then(function(foundUser) {
             if( !foundUser ) {
-              console.log('are we at least acknowledging that we didn\'t find a user?');
               return continueCreation(userAccount);
             }
           });
       });
 
-
+    // The second half of user creation has been extracted into a second function to allow us to short circuit user creation in the event that a user already exists.
     var continueCreation = function() {
-      console.log('are we making the hop to the other set of promises?');
 
       // Get github api information
       return apiHandler.getGithubData(userAccount)
 
       // Get user's Fitness Tracker's step-count
       .then(function() {
-        console.log('are we getting more data?');
         return apiHandler.getFitnessData(userAccount);
       })
 
       // Save user account to database
       .then(function(){
-        // res.json(userAccount);
         userCtrl.saveUser(res, userAccount);
       })
       // Catch any errors

--- a/server/auth/authRoutes.js
+++ b/server/auth/authRoutes.js
@@ -9,4 +9,7 @@ module.exports = function(app) {
   // Route from the /api/auth path. A GET request provides the codes which we convert into tokens (and all the data we need) by making requests from the relevant services.
   app.route('/createAccount')
     .get(authController.createNewUserAccount);
+
+  app.route('/loginAccount')
+    .get(authController.loginUser);
 };

--- a/server/users/userController.js
+++ b/server/users/userController.js
@@ -11,17 +11,17 @@ module.exports = {
 
   checkForUser: function(res, userAccount){
     var findOneUser = Q.nbind(User.findOne, User);
-    console.log(userAccount);
+
     // Check the database for the user
     return findOneUser({'xid': userAccount.github.user.id})
       .then(function(foundUser) {
-        console.log('this is "foundUser"', foundUser);
+
         // If we found a user under that xid, then return that user
         if(foundUser) {
-          console.log('I found one!');
           res.json(foundUser);
           return true;
-          // Otherwise we create a user and userServer document for that user's information
+
+        // Otherwise we inform the function that called this function that there is not a user under that ID, and allow it to decide what to do from there.
         } else {
           console.log('User does not exist');
           return false;


### PR DESCRIPTION
Refactor client-side authentication to contain three functions:

1)  getCode: uses AJAXParams function to make request through Chrome to get a provider's code.  Includes extra parameter to send github code to server for login (through sendToServer).

2)  sendToServer: contains two functionalities, pairing accounts (the old purpose, the same endpoint) and login, which passes along the github code to a new endpoint to be handled on the server.

3) syncServer: next to-do.

Server-side restructuring: tokenExchange handles both login and pairing cases, add loginAccount function and wiring
